### PR TITLE
添加了两个设置选项，并修正了站名显示问题

### DIFF
--- a/component/comments.php
+++ b/component/comments.php
@@ -61,6 +61,9 @@
             </form>
         </div>
     <?php else: ?>
-        <h3><?php _e('评论已关闭'); ?></h3>
+    <!--评论关闭显示样式-->
+    <?php if(!empty(getOptions()->footer_nocomment)) : ?>
+        <p><?php _e(getOptions()->footer_nocomment) ?></p>
+    <?php endif; ?>
     <?php endif; ?>
 </div>

--- a/footer.php
+++ b/footer.php
@@ -23,6 +23,12 @@ if (!defined('__TYPECHO_ROOT_DIR__')) exit;
         <br>
         <?php _e('Theme <a href="https://blog.lumirant.top/archives/51/">Ayakin</a> designed by <a href="https://Lumirant.top">Lumirant</a>'); ?>.
     <?php endif; ?>
+    <!-- 添加备案号 -->
+    <?php if(!empty(getOptions()->ICP_show)) : ?>
+        <br>
+        <?php echo '<a href="https://beian.miit.gov.cn/">' . getOptions()->ICP_show . '</a>'; ?>
+    <?php endif; ?>
+
 </footer><!-- end #footer -->
 
 <?php $this->footer(); ?>

--- a/functions.php
+++ b/functions.php
@@ -99,10 +99,29 @@ function themeConfig($form)
         null,
         '[{"type":"normal","title":"欢迎使用Ayakin！","content":"这是主题默认的公告，你可以在控制台-外观-设置外观-公告中修改或删除它。"}]',
         _t('公告'),
-        _t('会展示在网站首页，请按照 <a href="https://blog.lumirant.top/archives/57/">公告配置示范</a> 来填写此项')
+        _t('会展示在网站首页，请按照 <a href="https://blog.lumirant.top/archives/55/">公告配置示范</a> 来填写此项')
     );
 
     $form->addInput($notice);
+
+    $hiddenNav = new \Typecho\Widget\Helper\Form\Element\Checkbox(
+        'hiddenNav',
+        getCategoryies(true),
+        [],
+        _t('隐藏分类导航'),
+        _t('主题默认会将所有分类显示在导航栏上，如果你不想显示某些分类，请勾选对应的分类。')
+    );
+    $form->addInput($hiddenNav);
+    
+    $topArticle = new \Typecho\Widget\Helper\Form\Element\Text(
+        'topArticle',
+        null,
+        null,
+        _t('置顶文章'),
+        _t('需填入指定文章cid，多个文章用英文半角逗号“,”分隔。')
+    );
+
+    $form->addInput($topArticle);
     
     $avatarRootUrl = new \Typecho\Widget\Helper\Form\Element\Text(
         'avatarRootUrl',
@@ -134,15 +153,26 @@ function themeConfig($form)
 
     $form->addInput($simpleCopyright);
     
-    $topArticle = new \Typecho\Widget\Helper\Form\Element\Text(
-        'topArticle',
+    $footer_nocomment = new \Typecho\Widget\Helper\Form\Element\Text(
+        'footer_nocomment',
         null,
-        null,
-        _t('置顶文章'),
-        _t('需填入指定文章cid，多个文章用英文半角逗号“,”分隔。')
+        '评论已关闭',
+        _t('评论关闭的文字显示'),
+        _t('默认显示：“评论已关闭”')
     );
 
-    $form->addInput($topArticle);
+    $form->addInput($footer_nocomment);
+
+    $ICP_show = new \Typecho\Widget\Helper\Form\Element\Text(
+        'ICP_show',
+        null,
+        '',
+        _t('输入你的ICP备案号'),
+        _t('默认为空，填写后置于页脚底部')
+    );
+
+    $form->addInput($ICP_show);
+    
 
     $sidebarBlock = new \Typecho\Widget\Helper\Form\Element\Checkbox(
         'sidebarBlock',
@@ -159,21 +189,12 @@ function themeConfig($form)
 
     $form->addInput($sidebarBlock->multiMode());
     
-    $hiddenNav = new \Typecho\Widget\Helper\Form\Element\Checkbox(
-        'hiddenNav',
-        getCategoryies(true),
-        [],
-        _t('隐藏分类导航'),
-        _t('主题默认会将所有分类显示在导航栏上，如果你不想显示某些分类，请勾选对应的分类。')
-    );
-    $form->addInput($hiddenNav);
-    
     $additionalNav = new \Typecho_Widget_Helper_Form_Element_Textarea(
         'additionalNav',
         null,
         null,
         _t('附加导航'),
-        _t('会附加在导航栏尾部，请按照 <a href="https://blog.lumirant.top/archives/55/">附加导航配置示范</a> 来填写此项。')
+        _t('会附加在导航栏尾部，请按照 <a href="https://blog.lumirant.top/archives/57/">附加导航配置示范</a> 来填写此项。')
     );
 
     $form->addInput($additionalNav);

--- a/header.php
+++ b/header.php
@@ -34,7 +34,7 @@
 <header id="header" class="clearfix">
     <div class="container">
         <div class="flex row" style="line-height: 0;align-items: center;">
-            <div class="site-name col-mb-12 col-9" style="line-height: 1;">
+            <div class="site-name col-mb-12 col-9" style="line-height: normal;"> <!-- 设置了默认行高，避免网站名过长产生重叠 -->
                 <?php if (!empty(getOptions()->logoUrl)): ?>
                     <a id="logo" href="<?php $this->options->siteUrl(); ?>">
                         <img src="<?php getOptions()->logoUrl() ?>" alt="<?php $this->options->title() ?>"/>

--- a/header.php
+++ b/header.php
@@ -34,7 +34,7 @@
 <header id="header" class="clearfix">
     <div class="container">
         <div class="flex row" style="line-height: 0;align-items: center;">
-            <div class="site-name col-mb-12 col-9">
+            <div class="site-name col-mb-12 col-9" style="line-height: 1;">
                 <?php if (!empty(getOptions()->logoUrl)): ?>
                     <a id="logo" href="<?php $this->options->siteUrl(); ?>">
                         <img src="<?php getOptions()->logoUrl() ?>" alt="<?php $this->options->title() ?>"/>


### PR DESCRIPTION
我增加了两个设置功能：
- 评论关闭时，底部的文字显示
- 可以在页脚添加设置中写入的备案号，连接到工信部

另外，站名在中英混合，或者出现“-”等符号时，会首页渲染会出现字符重叠。我修改了site-name的行高为默认，让其溢出自动换行